### PR TITLE
docs: update project name

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,7 @@ module.exports = {
   baseUrl: "/muta-docs/",
   favicon: "/img/muta-logo.png",
   organizationName: "nervosnetwork",
-  projectName: "new-docs",
+  projectName: "muta-docs",
   customFields: {
     metadata: require("./metadata"),
   },


### PR DESCRIPTION
Using new documentation framework: https://v2.docusaurus.io/ 

More friendly and more powerful.
